### PR TITLE
Support for new roundIcon in android 7

### DIFF
--- a/updatePlatformConfig.js
+++ b/updatePlatformConfig.js
@@ -89,7 +89,8 @@ module.exports = function(context) {
                 'android-launchMode': {target: 'AndroidManifest.xml', parent: "__cordovaMainActivity__", destination: 'android:launchMode'},
                 'android-theme': {target: 'AndroidManifest.xml', parent: "__cordovaMainActivity__", destination: 'android:theme'},
                 'android-windowSoftInputMode': {target: 'AndroidManifest.xml', parent: "__cordovaMainActivity__", destination: 'android:windowSoftInputMode'},
-                'android-applicationName': {target: 'AndroidManifest.xml', parent: 'application', destination: 'android:name'}
+                'android-applicationName': {target: 'AndroidManifest.xml', parent: 'application', destination: 'android:name'},
+                'android-application-roundIcon': {target: 'AndroidManifest.xml', parent: 'application', destination: 'android:roundIcon'}
             },
             'ios': {}
         };


### PR DESCRIPTION
This is a tiny change that allow to change the AndroidManifest to use a custom icon for roundIcon, new in the SDK 25.

Example:

    <platform name="android">
        <preference name="android-application-roundIcon" value="@drawable/iconround" />
    </platform>